### PR TITLE
Show version on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,41 +4,48 @@ all: client server
 # Client build commands
 client-linux-i386:
 	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
-	GOOS=linux GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/linux/i386/engarde-client ./cmd/engarde-client
+	GOOS=linux GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/i386/engarde-client ./cmd/engarde-client
 client-linux-amd64:
 	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
-	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/linux/amd64/engarde-client ./cmd/engarde-client
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/amd64/engarde-client ./cmd/engarde-client
 client-linux-arm:
 	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
-	GOOS=linux GOARCH=arm go build -ldflags "-X main.Version=$$version" -o dist/linux/arm/engarde-client ./cmd/engarde-client
+	GOOS=linux GOARCH=arm go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/arm/engarde-client ./cmd/engarde-client
 client-windows-i386:
 	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
-	GOOS=windows GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/windows/i386/engarde-client.exe ./cmd/engarde-client
+	GOOS=windows GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/i386/engarde-client.exe ./cmd/engarde-client
 client-windows-amd64:
 	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
-	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/windows/amd64/engarde-client.exe ./cmd/engarde-client
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/amd64/engarde-client.exe ./cmd/engarde-client
 client-darwin-i386:
 	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
-	GOOS=darwin GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/darwin/i386/engarde-client ./cmd/engarde-client
+	GOOS=darwin GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/i386/engarde-client ./cmd/engarde-client
 client-darwin-amd64:
 	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/darwin/amd64/engarde-client ./cmd/engarde-client
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/amd64/engarde-client ./cmd/engarde-client
 
 # Server build commands
-server-linux-i386: ./cmd/engarde-server/
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-server ./cmd/engarde-server
-server-linux-amd64: ./cmd/engarde-server/
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-server ./cmd/engarde-server
-server-linux-arm: ./cmd/engarde-server/
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-server ./cmd/engarde-server
-server-windows-i386: ./cmd/engarde-server/
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-server.exe ./cmd/engarde-server
-server-windows-amd64: ./cmd/engarde-server/
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-server.exe ./cmd/engarde-server
-server-darwin-i386: ./cmd/engarde-server/
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-server ./cmd/engarde-server
-server-darwin-amd64: ./cmd/engarde-server/
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-server ./cmd/engarde-server
+server-linux-i386:
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	GOOS=linux GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/i386/engarde-server ./cmd/engarde-server
+server-linux-amd64:
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/amd64/engarde-server ./cmd/engarde-server
+server-linux-arm:
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	GOOS=linux GOARCH=arm go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/arm/engarde-server ./cmd/engarde-server
+server-windows-i386:
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	GOOS=windows GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/i386/engarde-server.exe ./cmd/engarde-server
+server-windows-amd64:
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/amd64/engarde-server.exe ./cmd/engarde-server
+server-darwin-i386:
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	GOOS=darwin GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/i386/engarde-server ./cmd/engarde-server
+server-darwin-amd64:
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/amd64/engarde-server ./cmd/engarde-server
 
 # Platform-specific builds
 linux-i386: client-linux-i386 server-linux-i386

--- a/Makefile
+++ b/Makefile
@@ -3,25 +3,25 @@ all: client server
 
 # Client build commands
 client-linux-i386:
-	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/linux/i386/engarde-client ./cmd/engarde-client
 client-linux-amd64:
-	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/linux/amd64/engarde-client ./cmd/engarde-client
 client-linux-arm:
-	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=arm go build -ldflags "-X main.Version=$$version" -o dist/linux/arm/engarde-client ./cmd/engarde-client
 client-windows-i386:
-	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=windows GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/windows/i386/engarde-client.exe ./cmd/engarde-client
 client-windows-amd64:
-	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/windows/amd64/engarde-client.exe ./cmd/engarde-client
 client-darwin-i386:
-	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=darwin GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/darwin/i386/engarde-client ./cmd/engarde-client
 client-darwin-amd64:
-	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/darwin/amd64/engarde-client ./cmd/engarde-client
 
 # Server build commands

--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,27 @@
 all: client server
 
 # Client build commands
-client-linux-i386: ./cmd/engarde-client/
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-client ./cmd/engarde-client
-client-linux-amd64: ./cmd/engarde-client/
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-client ./cmd/engarde-client
+client-linux-i386:
+	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	GOOS=linux GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/linux/i386/engarde-client ./cmd/engarde-client
+client-linux-amd64:
+	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/linux/amd64/engarde-client ./cmd/engarde-client
 client-linux-arm:
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-client ./cmd/engarde-client
-client-windows-i386: ./cmd/engarde-client/
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-client.exe ./cmd/engarde-client
-client-windows-amd64: ./cmd/engarde-client/
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-client.exe ./cmd/engarde-client
-client-darwin-i386: ./cmd/engarde-client/
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-client ./cmd/engarde-client
-client-darwin-amd64: ./cmd/engarde-client/
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-client ./cmd/engarde-client
+	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	GOOS=linux GOARCH=arm go build -ldflags "-X main.Version=$$version" -o dist/linux/arm/engarde-client ./cmd/engarde-client
+client-windows-i386:
+	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	GOOS=windows GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/windows/i386/engarde-client.exe ./cmd/engarde-client
+client-windows-amd64:
+	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/windows/amd64/engarde-client.exe ./cmd/engarde-client
+client-darwin-i386:
+	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	GOOS=darwin GOARCH=386 go build -ldflags "-X main.Version=$$version" -o dist/darwin/i386/engarde-client ./cmd/engarde-client
+client-darwin-amd64:
+	if [ $$GIT_COMMIT != "" ]; then version="$$GIT_COMMIT ($$GIT_BRANCH)"; fi; \
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=$$version" -o dist/darwin/amd64/engarde-client ./cmd/engarde-client
 
 # Server build commands
 server-linux-i386: ./cmd/engarde-server/

--- a/Makefile
+++ b/Makefile
@@ -3,48 +3,48 @@ all: client server
 
 # Client build commands
 client-linux-i386:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/i386/engarde-client ./cmd/engarde-client
 client-linux-amd64:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/amd64/engarde-client ./cmd/engarde-client
 client-linux-arm:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=arm go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/arm/engarde-client ./cmd/engarde-client
 client-windows-i386:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=windows GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/i386/engarde-client.exe ./cmd/engarde-client
 client-windows-amd64:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=windows GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/amd64/engarde-client.exe ./cmd/engarde-client
 client-darwin-i386:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=darwin GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/i386/engarde-client ./cmd/engarde-client
 client-darwin-amd64:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/amd64/engarde-client ./cmd/engarde-client
 
 # Server build commands
 server-linux-i386:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/i386/engarde-server ./cmd/engarde-server
 server-linux-amd64:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/amd64/engarde-server ./cmd/engarde-server
 server-linux-arm:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=linux GOARCH=arm go build -ldflags "-X 'main.Version=$$version'" -o dist/linux/arm/engarde-server ./cmd/engarde-server
 server-windows-i386:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=windows GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/i386/engarde-server.exe ./cmd/engarde-server
 server-windows-amd64:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=windows GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/windows/amd64/engarde-server.exe ./cmd/engarde-server
 server-darwin-i386:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=darwin GOARCH=386 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/i386/engarde-server ./cmd/engarde-server
 server-darwin-amd64:
-	if [ "$$TRAVIS_COMMIT" != "" ]; then version="$$TRAVIS_COMMIT ($$TRAVIS_BRANCH)"; fi; \
+	if [ "$$TRAVIS_COMMIT" != "" ]; then commit=$$(echo $$TRAVIS_COMMIT | head -c 7); version="$$commit ($$TRAVIS_BRANCH)"; fi; \
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.Version=$$version'" -o dist/darwin/amd64/engarde-server ./cmd/engarde-server
 
 # Platform-specific builds

--- a/cmd/engarde-client/main.go
+++ b/cmd/engarde-client/main.go
@@ -38,6 +38,9 @@ type sendingRoutine struct {
 var sendingChannels map[string]*sendingRoutine
 var clConfig clientConfig
 
+// Version is passed by the compiler
+var Version string
+
 func handleErr(err error, msg string) {
 	if err != nil {
 		log.Fatal(msg+" | ", err)
@@ -226,6 +229,12 @@ func receiveFromWireguard(wgsock *net.UDPConn, sourceAddr **net.UDPAddr) {
 	}
 }
 
+func printVersion() {
+	if Version != "" {
+		print("engarde-client ver. " + Version + "\r\n")
+	}
+}
+
 func main() {
 	var genconfig config
 	var configName string
@@ -234,6 +243,14 @@ func main() {
 	} else {
 		configName = "engarde.yml"
 	}
+
+	printVersion()
+
+	// If flag is -v, exit after printing version
+	if configName == "-v" {
+		return
+	}
+
 	if configName == "list-interfaces" {
 		listInterfaces()
 		return

--- a/cmd/engarde-server/main.go
+++ b/cmd/engarde-server/main.go
@@ -30,6 +30,9 @@ type ConnectedClient struct {
 var clients map[string]*ConnectedClient
 var srConfig serverConfig
 
+// Version is passed by the compiler
+var Version string
+
 func handleErr(err error, msg string) {
 	if err != nil {
 		log.Fatal(msg+" | ", err)
@@ -45,6 +48,12 @@ func getClientByAddr(addr *net.UDPAddr) *ConnectedClient {
 	return nil
 }
 
+func printVersion() {
+	if Version != "" {
+		print("engarde-server ver. " + Version + "\r\n")
+	}
+}
+
 func main() {
 	var genconfig config
 	var configName string
@@ -53,6 +62,14 @@ func main() {
 	} else {
 		configName = "engarde.yml"
 	}
+
+	printVersion()
+
+	// If flag is -v, exit after printing version
+	if configName == "-v" {
+		return
+	}
+
 	yamlFile, err := ioutil.ReadFile(configName)
 	handleErr(err, "Reading config file "+configName+" failed")
 	err = yaml.Unmarshal(yamlFile, &genconfig)


### PR DESCRIPTION
Fix #5 

The commit and branch reference is printed at startup, and it's the only printed thing when the -v argument is passed.

The whole string "commit (branch)" is generated in the compile script and passed on as a single variable, so it will be easy to replace with a version number when we'll begin doing releases.

@xela92 please check that builds at http://www.linuxzogno.org/engarde/builds/fix/3-show-version-on-startup solve the issue for you, then fill free to accept the pull request.