### PR TITLE
Bind to interfaces on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,35 +3,35 @@ all: client server
 
 # Client build commands
 client-linux-i386: cmd/engarde-client/
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-client cmd/engarde-client/
+	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-client cmd/engarde-client
 client-linux-amd64: cmd/engarde-client/
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-client cmd/engarde-client/
+	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-client cmd/engarde-client
 client-linux-arm:
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-client cmd/engarde-client/
+	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-client cmd/engarde-client
 client-windows-i386: cmd/engarde-client/
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-client.exe cmd/engarde-client/
+	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-client.exe cmd/engarde-client
 client-windows-amd64: cmd/engarde-client/
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-client.exe cmd/engarde-client/
+	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-client.exe cmd/engarde-client
 client-darwin-i386: cmd/engarde-client/
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-client cmd/engarde-client/
+	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-client cmd/engarde-client
 client-darwin-amd64: cmd/engarde-client/
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-client cmd/engarde-client/
+	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-client cmd/engarde-client
 
 # Server build commands
 server-linux-i386: cmd/engarde-server/
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-server cmd/engarde-server/
+	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-server cmd/engarde-server
 server-linux-amd64: cmd/engarde-server/
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-server cmd/engarde-server/
+	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-server cmd/engarde-server
 server-linux-arm: cmd/engarde-server/
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-server cmd/engarde-server/
+	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-server cmd/engarde-server
 server-windows-i386: cmd/engarde-server/
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-server.exe cmd/engarde-server/
+	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-server.exe cmd/engarde-server
 server-windows-amd64: cmd/engarde-server/
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-server.exe cmd/engarde-server/
+	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-server.exe cmd/engarde-server
 server-darwin-i386: cmd/engarde-server/
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-server cmd/engarde-server/
+	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-server cmd/engarde-server
 server-darwin-amd64: cmd/engarde-server/
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-server cmd/engarde-server/
+	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-server cmd/engarde-server
 
 # Platform-specific builds
 linux-i386: client-linux-i386 server-linux-i386

--- a/Makefile
+++ b/Makefile
@@ -2,36 +2,36 @@
 all: client server
 
 # Client build commands
-client-linux-i386: cmd/engarde-client/
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-client cmd/engarde-client
-client-linux-amd64: cmd/engarde-client/
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-client cmd/engarde-client
+client-linux-i386: ./cmd/engarde-client/
+	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-client ./cmd/engarde-client
+client-linux-amd64: ./cmd/engarde-client/
+	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-client ./cmd/engarde-client
 client-linux-arm:
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-client cmd/engarde-client
-client-windows-i386: cmd/engarde-client/
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-client.exe cmd/engarde-client
-client-windows-amd64: cmd/engarde-client/
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-client.exe cmd/engarde-client
-client-darwin-i386: cmd/engarde-client/
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-client cmd/engarde-client
-client-darwin-amd64: cmd/engarde-client/
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-client cmd/engarde-client
+	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-client ./cmd/engarde-client
+client-windows-i386: ./cmd/engarde-client/
+	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-client.exe ./cmd/engarde-client
+client-windows-amd64: ./cmd/engarde-client/
+	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-client.exe ./cmd/engarde-client
+client-darwin-i386: ./cmd/engarde-client/
+	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-client ./cmd/engarde-client
+client-darwin-amd64: ./cmd/engarde-client/
+	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-client ./cmd/engarde-client
 
 # Server build commands
-server-linux-i386: cmd/engarde-server/
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-server cmd/engarde-server
-server-linux-amd64: cmd/engarde-server/
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-server cmd/engarde-server
-server-linux-arm: cmd/engarde-server/
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-server cmd/engarde-server
-server-windows-i386: cmd/engarde-server/
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-server.exe cmd/engarde-server
-server-windows-amd64: cmd/engarde-server/
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-server.exe cmd/engarde-server
-server-darwin-i386: cmd/engarde-server/
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-server cmd/engarde-server
-server-darwin-amd64: cmd/engarde-server/
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-server cmd/engarde-server
+server-linux-i386: ./cmd/engarde-server/
+	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-server ./cmd/engarde-server
+server-linux-amd64: ./cmd/engarde-server/
+	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-server ./cmd/engarde-server
+server-linux-arm: ./cmd/engarde-server/
+	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-server ./cmd/engarde-server
+server-windows-i386: ./cmd/engarde-server/
+	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-server.exe ./cmd/engarde-server
+server-windows-amd64: ./cmd/engarde-server/
+	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-server.exe ./cmd/engarde-server
+server-darwin-i386: ./cmd/engarde-server/
+	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-server ./cmd/engarde-server
+server-darwin-amd64: ./cmd/engarde-server/
+	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-server ./cmd/engarde-server
 
 # Platform-specific builds
 linux-i386: client-linux-i386 server-linux-i386

--- a/Makefile
+++ b/Makefile
@@ -2,36 +2,36 @@
 all: client server
 
 # Client build commands
-client-linux-i386: cmd/engarde-client/main.go
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-client cmd/engarde-client/main.go
-client-linux-amd64: cmd/engarde-client/main.go
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-client cmd/engarde-client/main.go
+client-linux-i386: cmd/engarde-client/
+	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-client cmd/engarde-client/
+client-linux-amd64: cmd/engarde-client/
+	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-client cmd/engarde-client/
 client-linux-arm:
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-client cmd/engarde-client/main.go
-client-windows-i386: cmd/engarde-client/main.go
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-client.exe cmd/engarde-client/main.go
-client-windows-amd64: cmd/engarde-client/main.go
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-client.exe cmd/engarde-client/main.go
-client-darwin-i386: cmd/engarde-client/main.go
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-client cmd/engarde-client/main.go
-client-darwin-amd64: cmd/engarde-client/main.go
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-client cmd/engarde-client/main.go
+	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-client cmd/engarde-client/
+client-windows-i386: cmd/engarde-client/
+	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-client.exe cmd/engarde-client/
+client-windows-amd64: cmd/engarde-client/
+	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-client.exe cmd/engarde-client/
+client-darwin-i386: cmd/engarde-client/
+	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-client cmd/engarde-client/
+client-darwin-amd64: cmd/engarde-client/
+	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-client cmd/engarde-client/
 
 # Server build commands
-server-linux-i386: cmd/engarde-server/main.go
-	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-server cmd/engarde-server/main.go
-server-linux-amd64: cmd/engarde-server/main.go
-	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-server cmd/engarde-server/main.go
-server-linux-arm: cmd/engarde-server/main.go
-	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-server cmd/engarde-server/main.go
-server-windows-i386: cmd/engarde-server/main.go
-	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-server.exe cmd/engarde-server/main.go
-server-windows-amd64: cmd/engarde-server/main.go
-	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-server.exe cmd/engarde-server/main.go
-server-darwin-i386: cmd/engarde-server/main.go
-	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-server cmd/engarde-server/main.go
-server-darwin-amd64: cmd/engarde-server/main.go
-	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-server cmd/engarde-server/main.go
+server-linux-i386: cmd/engarde-server/
+	GOOS=linux GOARCH=386 go build -o dist/linux/i386/engarde-server cmd/engarde-server/
+server-linux-amd64: cmd/engarde-server/
+	GOOS=linux GOARCH=amd64 go build -o dist/linux/amd64/engarde-server cmd/engarde-server/
+server-linux-arm: cmd/engarde-server/
+	GOOS=linux GOARCH=arm go build -o dist/linux/arm/engarde-server cmd/engarde-server/
+server-windows-i386: cmd/engarde-server/
+	GOOS=windows GOARCH=386 go build -o dist/windows/i386/engarde-server.exe cmd/engarde-server/
+server-windows-amd64: cmd/engarde-server/
+	GOOS=windows GOARCH=amd64 go build -o dist/windows/amd64/engarde-server.exe cmd/engarde-server/
+server-darwin-i386: cmd/engarde-server/
+	GOOS=darwin GOARCH=386 go build -o dist/darwin/i386/engarde-server cmd/engarde-server/
+server-darwin-amd64: cmd/engarde-server/
+	GOOS=darwin GOARCH=amd64 go build -o dist/darwin/amd64/engarde-server cmd/engarde-server/
 
 # Platform-specific builds
 linux-i386: client-linux-i386 server-linux-i386

--- a/cmd/engarde-client/main.go
+++ b/cmd/engarde-client/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"strings"
-	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -163,43 +161,6 @@ func updateAvailableInterfaces(wgSock *net.UDPConn, wgAddr **net.UDPAddr) {
 		}
 		time.Sleep(1 * time.Second)
 	}
-}
-
-/* Borrowed from https://github.com/udhos/nexthop/ - Thanks! */
-func udpConn(laddr *net.UDPAddr, ifname string) (*net.UDPConn, error) {
-	if laddr == nil {
-		laddr = &net.UDPAddr{IP: net.IPv4zero, Port: 0}
-	}
-	s, err1 := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
-	if err1 != nil {
-		return nil, fmt.Errorf("Could not create socket(laddr=%v,ifname=%s): %v", laddr, ifname, err1)
-	}
-	if err := syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
-		syscall.Close(s)
-		return nil, fmt.Errorf("Could not set reuse addr socket(laddr=%v,ifname=%s): %v", laddr, ifname, err)
-	}
-	if ifname != "" {
-		if err := syscall.SetsockoptString(s, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, ifname); err != nil {
-			syscall.Close(s)
-			return nil, fmt.Errorf("Could not bind to device socket(laddr=%v, ifname=%s): %v", laddr, ifname, err)
-		}
-	}
-	lsa := syscall.SockaddrInet4{Port: laddr.Port}
-	copy(lsa.Addr[:], laddr.IP.To4())
-
-	if err := syscall.Bind(s, &lsa); err != nil {
-		syscall.Close(s)
-		return nil, fmt.Errorf("Could not bind socket to address %v: %v", laddr, err)
-	}
-	f := os.NewFile(uintptr(s), "")
-	c, err2 := net.FilePacketConn(f)
-	f.Close()
-	if err2 != nil {
-		syscall.Close(s)
-		return nil, fmt.Errorf("Could not get packet connection for socket(laddr=%v,ifname=%s): %v", laddr, ifname, err2)
-	}
-
-	return c.(*net.UDPConn), nil
 }
 
 func createSendThread(ifname, sourceAddr string, wgSock *net.UDPConn, wgAddr **net.UDPAddr) {

--- a/cmd/engarde-client/main.go
+++ b/cmd/engarde-client/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -163,6 +165,43 @@ func updateAvailableInterfaces(wgSock *net.UDPConn, wgAddr **net.UDPAddr) {
 	}
 }
 
+/* Borrowed from https://github.com/udhos/nexthop/ - Thanks! */
+func udpConn(laddr *net.UDPAddr, ifname string) (*net.UDPConn, error) {
+	if laddr == nil {
+		laddr = &net.UDPAddr{IP: net.IPv4zero, Port: 0}
+	}
+	s, err1 := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
+	if err1 != nil {
+		return nil, fmt.Errorf("Could not create socket(laddr=%v,ifname=%s): %v", laddr, ifname, err1)
+	}
+	if err := syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		syscall.Close(s)
+		return nil, fmt.Errorf("Could not set reuse addr socket(laddr=%v,ifname=%s): %v", laddr, ifname, err)
+	}
+	if ifname != "" {
+		if err := syscall.SetsockoptString(s, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, ifname); err != nil {
+			syscall.Close(s)
+			return nil, fmt.Errorf("Could not bind to device socket(laddr=%v, ifname=%s): %v", laddr, ifname, err)
+		}
+	}
+	lsa := syscall.SockaddrInet4{Port: laddr.Port}
+	copy(lsa.Addr[:], laddr.IP.To4())
+
+	if err := syscall.Bind(s, &lsa); err != nil {
+		syscall.Close(s)
+		return nil, fmt.Errorf("Could not bind socket to address %v: %v", laddr, err)
+	}
+	f := os.NewFile(uintptr(s), "")
+	c, err2 := net.FilePacketConn(f)
+	f.Close()
+	if err2 != nil {
+		syscall.Close(s)
+		return nil, fmt.Errorf("Could not get packet connection for socket(laddr=%v,ifname=%s): %v", laddr, ifname, err2)
+	}
+
+	return c.(*net.UDPConn), nil
+}
+
 func createSendThread(ifname, sourceAddr string, wgSock *net.UDPConn, wgAddr **net.UDPAddr) {
 	dst := getDstOverrideByIfname(ifname)
 	if dst == "" {
@@ -178,7 +217,7 @@ func createSendThread(ifname, sourceAddr string, wgSock *net.UDPConn, wgAddr **n
 		log.Error("Can't resolve source address '" + sourceAddr + "' for interface '" + ifname + "', not using it")
 		return
 	}
-	sock, err := net.ListenUDP("udp", srcAddr)
+	sock, err := udpConn(srcAddr, ifname)
 	if err != nil {
 		log.Error("Can't create socket for address '" + sourceAddr + "' on interface '" + ifname + "', not using it")
 		return

--- a/cmd/engarde-client/udpconn.go
+++ b/cmd/engarde-client/udpconn.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package main
+
+import (
+	"net"
+)
+
+// In Windows, it's enough to listen on a particular address to bind to its interface
+func udpConn(laddr *net.UDPAddr, ifname string) (*net.UDPConn, error) {
+	return net.ListenUDP("udp", laddr)
+}

--- a/cmd/engarde-client/udpconn.go
+++ b/cmd/engarde-client/udpconn.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows darwin
 
 package main
 

--- a/cmd/engarde-client/udpconn_bindtodevice.go
+++ b/cmd/engarde-client/udpconn_bindtodevice.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 package main
 

--- a/cmd/engarde-client/udpconn_bindtodevice.go
+++ b/cmd/engarde-client/udpconn_bindtodevice.go
@@ -1,0 +1,47 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+)
+
+/* Borrowed from https://github.com/udhos/nexthop/ - Thanks! */
+func udpConn(laddr *net.UDPAddr, ifname string) (*net.UDPConn, error) {
+	if laddr == nil {
+		laddr = &net.UDPAddr{IP: net.IPv4zero, Port: 0}
+	}
+	s, err1 := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
+	if err1 != nil {
+		return nil, fmt.Errorf("Could not create socket(laddr=%v,ifname=%s): %v", laddr, ifname, err1)
+	}
+	if err := syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		syscall.Close(s)
+		return nil, fmt.Errorf("Could not set reuse addr socket(laddr=%v,ifname=%s): %v", laddr, ifname, err)
+	}
+	if ifname != "" {
+		if err := syscall.SetsockoptString(s, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, ifname); err != nil {
+			syscall.Close(s)
+			return nil, fmt.Errorf("Could not bind to device socket(laddr=%v, ifname=%s): %v", laddr, ifname, err)
+		}
+	}
+	lsa := syscall.SockaddrInet4{Port: laddr.Port}
+	copy(lsa.Addr[:], laddr.IP.To4())
+
+	if err := syscall.Bind(s, &lsa); err != nil {
+		syscall.Close(s)
+		return nil, fmt.Errorf("Could not bind socket to address %v: %v", laddr, err)
+	}
+	f := os.NewFile(uintptr(s), "")
+	c, err2 := net.FilePacketConn(f)
+	f.Close()
+	if err2 != nil {
+		syscall.Close(s)
+		return nil, fmt.Errorf("Could not get packet connection for socket(laddr=%v,ifname=%s): %v", laddr, ifname, err2)
+	}
+
+	return c.(*net.UDPConn), nil
+}


### PR DESCRIPTION
Fix #6 

Separate the client UDP connection creation between Windows/Darwin and Linux/derivatives, using the SO_BINDTODEVICE system call on the latter to bind to the correct device.