### PR TITLE
Retry every second (+1500ms timeout), no snackbar, no retry

### DIFF
--- a/webmanager/src/app/app.component.html
+++ b/webmanager/src/app/app.component.html
@@ -5,9 +5,9 @@
             <div *ngIf="version" class="version">ver. {{ version }}</div>
         </app-actionbar>
         <div *ngIf="type == 'client'" [@scaleIn]>
-    
+
             <!-- ACTIVE INTERFACES -->
-    
+
             <p class="subtitle main-text">Active interfaces
                 <button mat-button (mouseenter)="hintAnimationActive = true" (mouseleave)="hintAnimationActive = false">?</button>
             </p>
@@ -32,9 +32,9 @@
                 </mat-card>
                 <p class="no-results alert" *ngIf="(ifaces | callback: filterActive)?.length == 0">There are no active interfaces.</p>
             </div>
-    
+
             <!-- IDLE INTERFACES -->
-    
+
             <p class="subtitle main-text">Idle interfaces
                 <button mat-button (mouseenter)="hintAnimationIdle = true" (mouseleave)="hintAnimationIdle = false">?</button>
             </p>
@@ -56,9 +56,9 @@
                 </mat-card>
                 <p class="no-results" *ngIf="(ifaces | callback: filterIdle)?.length == 0">There are no idle interfaces.</p>
             </div>
-    
+
             <!-- EXCLUDED INTERFACES -->
-    
+
             <p class="subtitle main-text">Excluded interfaces
                 <button mat-button (mouseenter)="hintAnimationExcluded = true" (mouseleave)="hintAnimationExcluded = false">?</button>
             </p>
@@ -82,9 +82,9 @@
             <p>
                 <button mat-button (click)="resetExcludes()">Reset all exclusions</button>
             </p>
-    
+
         </div>
-    
+
         <div *ngIf="type == 'server'">
             <p class="subtitle main-text">Active sockets
                 <button mat-button (mouseenter)="hintAnimationActive = true" (mouseleave)="hintAnimationActive = false">?</button>
@@ -104,17 +104,16 @@
             </div>
         </div>
     </div>
-    
+
     <ng-template #errScreen>
         <app-actionbar [title]="'ENGARDE'" [color]="'#03A9F4'" [textColor]="'white'">
             <div class="subtitle"> WEBUI</div>
         </app-actionbar>
         <div *ngIf="loaded == true" class="main-text">
             <div class="title">ERROR: {{errorMessage.statusText || errorMessage}}</div>
-            <div class="subtitle">Will check every 10 seconds</div>
-            <button mat-raised-button color="accent" style="margin: 2vh; color: white;" (click)="manualGetList()">Retry</button>
+            <div class="subtitle">There's a problem reaching engarde right now. The page will be update as soon as it's solved.</div>
         </div>
-    
+
     </ng-template>
-    
+
     <router-outlet></router-outlet>

--- a/webmanager/src/app/app.component.ts
+++ b/webmanager/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { IfaceModel } from './models/iface.model';
 import { SocketModel } from './models/socket.model';
 import { getScaleInAnimation } from './animations/scalein.animation';
 import { DataTableConfig } from './components/mydatatable/models/mydatatable/datatableconfig.model';
-import { MatSnackBar, MatSnackBarConfig, MatDialog, MatDialogRef } from '@angular/material';
+import { MatDialog, MatDialogRef } from '@angular/material';
 import { getSlideOutAnimation } from './animations/slideout.animation';
 import { DialogComponent } from './components/dialog/dialog.component';
 import { RespModel } from './models/resp.model';
@@ -25,7 +25,6 @@ export class AppComponent {
   public sockets: SocketModel[]
   public errorMessage;
   public loaded : boolean = false;
-  public snackBarConfig;
   public hintAnimationActive : boolean = false;
   public hintAnimationIdle : boolean = false;
   public hintAnimationExcluded : boolean = false;
@@ -36,18 +35,7 @@ export class AppComponent {
   }
 
 
-  constructor(public api: APICallerService, public snackBar: MatSnackBar, public dialog: MatDialog) {
-    this.snackBarConfig = new MatSnackBarConfig();
-    this.snackBarConfig.panelClass = ['snackbar']  
-    this.snackBarConfig.duration = 1000;
-  }
-  
-  manualGetList() {
-    if(this.listTimeout) {
-      clearTimeout(this.listTimeout)
-    }
-    this.getList()
-  }
+  constructor(public api: APICallerService, public dialog: MatDialog) { }
 
   getList() {
     this.listTimeout = null;
@@ -76,11 +64,10 @@ export class AppComponent {
         this.type = null;
         this.loaded = true;
         this.errorMessage = err.statusText || err.message ;
-        this.snackBar.open(`ERR: ${this.errorMessage}`, null, this.snackBarConfig);
         if(this.listTimeout) {
           clearTimeout(this.listTimeout)
         }
-        this.listTimeout = window.setTimeout(() => { this.getList() }, 10000);
+        this.listTimeout = window.setTimeout(() => { this.getList() }, 1000);
       } else {
         let callDuration = new Date().getTime() - startTime
         if(this.listTimeout) {
@@ -111,13 +98,13 @@ export class AppComponent {
   trackByAddress(index, iface) {
     return iface.address;
   }
-  
+
   toggleExclude(ifname: string) {
     let activeIfaces = this.ifaces.filter(i => i.status == "active");
     if (activeIfaces.length == 1  && activeIfaces[0].name === ifname) {
         this.dialog.open(DialogComponent, { data:{
           title: "OCIO! WARNING!",
-          content: `Ehi, wait a second. You're going to exclude the only active interface. 
+          content: `Ehi, wait a second. You're going to exclude the only active interface.
           This way, the tunnel will go down FOR SURE! Do you <b>REALLY</b> want to proceed?`,
           thingsToBeDone : [
             {
@@ -138,7 +125,7 @@ export class AppComponent {
   resetExcludes() {
     this.api.clearOverrides()
   }
-  
+
   ngOnInit() {
     this.getList();
   }


### PR DESCRIPTION
The change was made to avoid handling concurrency issues when a user continuously clicks _Retry_, which is quite a normal behaviour.  
Moreover, I prefer this kind of interaction as it gives the user a feeling of "real-time data" even in case of error.

Builds are available at https://engarde.linuxzogno.org/builds/fix/webui-error-management : please test them and ensure they're working properly for you before approving.

Thank you